### PR TITLE
Update EloquentBuilderTrait.php

### DIFF
--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -267,7 +267,7 @@ trait EloquentBuilderTrait
      * @param Builder $queryBuilder
      * @param $key
      */
-    private function joinRelatedModelIfExists(Builder $queryBuilder, $key)
+    protected function joinRelatedModelIfExists(Builder $queryBuilder, $key)
     {
         $model = $queryBuilder->getModel();
 
@@ -279,9 +279,9 @@ trait EloquentBuilderTrait
             if ($relation instanceof BelongsTo) {
                 $queryBuilder->join(
                     $relation->getRelated()->getTable(),
-                    $model->getTable().'.'.$relation->getQualifiedForeignKeyName(),
+                    $relation->getQualifiedForeignKey(),
                     '=',
-                    $relation->getRelated()->getTable().'.'.$relation->getOwnerKey(),
+                    $relation->getQualifiedOwnerKeyName(),
                     $type
                 );
             } elseif ($relation instanceof BelongsToMany) {


### PR DESCRIPTION
FIxed EloquentBuilderTrait. This is identical to PR #31, but in addition I have made the `joinRelatedModelIfExists` method protected. In 18 years of PHP development I have never come across any legitimate reason for making a method private. Making this method private means that it cannot be overridden. In the case of this bug in the EloquentBuilderTrait, it means that there is no easy way to override that method to fix the bug..